### PR TITLE
feat: rtk request camelize

### DIFF
--- a/features/info/api/getRepoInfo.ts
+++ b/features/info/api/getRepoInfo.ts
@@ -1,5 +1,4 @@
 import { RepoInfoTypes as RepoInfoResponse } from "@features/info/types";
-import { convertObjectToCamelCase } from "@utils";
 import { githubApiService } from "@utils/apiUtils";
 
 type Params = {
@@ -16,9 +15,6 @@ export const repoInfoApi = githubApiService.injectEndpoints({
         }
 
         return `repos/${params.username}/${params.repo}`;
-      },
-      transformResponse: (response: RepoInfoResponse) => {
-        return convertObjectToCamelCase<RepoInfoResponse>(response);
       },
     }),
   }),

--- a/features/repos/api/getRecommendations.ts
+++ b/features/repos/api/getRecommendations.ts
@@ -1,4 +1,3 @@
-import { convertObjectToCamelCase } from "@utils";
 import { githubApiService } from "@utils/apiUtils";
 
 export interface ResponseItem {
@@ -25,9 +24,6 @@ export const recommendationsApi = githubApiService.injectEndpoints({
   endpoints: builder => ({
     fetchRecommendation: builder.query<IResponse, QueryArg>({
       query: ({ repoName, page }) => `search/repositories?q=${repoName}&per_page=10&page=${page}`,
-      transformResponse: (response: IResponse) => {
-        return convertObjectToCamelCase<IResponse>(response);
-      },
     }),
   }),
   overrideExisting: false,


### PR DESCRIPTION
# Description
Use the camel case logic where we define our base query in `createApi` instead of using the camelize logic in `transformResponse` of each and every endpoint.